### PR TITLE
feat: separate nvm configuration into modular file

### DIFF
--- a/.config/zsh/config.d/exports.zsh
+++ b/.config/zsh/config.d/exports.zsh
@@ -13,10 +13,6 @@ if command -v pyenv 1>/dev/null 2>&1; then
   eval "$(pyenv init - zsh)"
 fi
 
-# NVM
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-
 # Bun
 export BUN_INSTALL="$HOME/.bun"
 [ -d "$BUN_INSTALL/bin" ] && export PATH="$BUN_INSTALL/bin:$PATH"

--- a/.config/zsh/config.d/nvm.zsh
+++ b/.config/zsh/config.d/nvm.zsh
@@ -1,0 +1,16 @@
+# NVM Configuration
+export NVM_DIR="$HOME/.nvm"
+
+# Load NVM
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  source "$NVM_DIR/nvm.sh"
+elif [ -s "/usr/local/opt/nvm/nvm.sh" ]; then
+  source "/usr/local/opt/nvm/nvm.sh"
+fi
+
+# Load NVM Completion
+if [ -s "$NVM_DIR/bash_completion" ]; then
+  source "$NVM_DIR/bash_completion"
+elif [ -s "/usr/local/opt/nvm/etc/bash_completion.d/nvm" ]; then
+  source "/usr/local/opt/nvm/etc/bash_completion.d/nvm"
+fi


### PR DESCRIPTION
Moves NVM configuration from exports.zsh to its own config.d/nvm.zsh for better modularity and visibility.